### PR TITLE
Fix: Zod password special symbol validation regex

### DIFF
--- a/src/z/new-types/password.test.ts
+++ b/src/z/new-types/password.test.ts
@@ -22,19 +22,19 @@ describe('password', () => {
   it('should validate at least one digit', () => {
     schema = password().atLeastOne('digit')
     is('sdfghfd4isugh', true)
-    is('aihsdgih', false)
+    is('Aihsdgih!', false)
   })
 
   it('should validate at least one lowercase', () => {
     schema = password().atLeastOne('lowercase')
     is('SDFUfFIDD', true)
-    is('DSIFHUSDHUF', false)
+    is('DSIFHUSDHUF!3', false)
   })
 
   it('should validate at least one uppercase', () => {
     schema = password().atLeastOne('uppercase')
     is('fdhgidUhfg', true)
-    is('dsifghfodih', false)
+    is('dsifghfodih!3', false)
   })
 
   it('should validate at least one special', () => {
@@ -46,7 +46,7 @@ describe('password', () => {
       is(`asfosd${char}sadfas`, true)
     }
 
-    is('aihsdgih', false)
+    is('Aihsdgih3', false)
   })
 
   const small = '213'

--- a/src/z/new-types/password.ts
+++ b/src/z/new-types/password.ts
@@ -48,7 +48,7 @@ const REGEXPS: Record<SymbolKind, RegExp> = {
   digit: /\d/,
   lowercase: /[a-z]/,
   uppercase: /[A-Z]/,
-  special: /[!?@#$%^&*{};.,:%№"|\\/()-_+=<>`~[\]'"]/,
+  special: /[!?@#$%^&*{};.,:%№"|\\/()\-_+=<>`~[\]'"]/,
 }
 
 function isSymbolCheck(


### PR DESCRIPTION
The `-` character in the special symbol validation regex was not escaped. This lead to the validation regex accepting uppercase letters and numbers as well:

![image](https://github.com/risen228/nestjs-zod/assets/22303108/d8f72005-c164-43b7-ae24-51ec65e6bce2)
 
- Fix validation regex
- Enhance zod password unit tests