### PR TITLE
feat: support zod native string date-time

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ As you learned in [Writing Zod Schemas](#writing-zod-schemas) section, `nestjs-z
 
 ### ZodDateString
 
-In HTTP, we always accept Dates as strings. But default Zod doesn't have methods to validate such type of strings. `ZodDateString` was created to address this issue.
+In HTTP, we always accept Dates as strings. But default Zod only has validations for full date-time strings. `ZodDateString` was created to address this issue.
 
 ```ts
 // 1. Expect user input to be a "string" type

--- a/src/openapi/__snapshots__/zod-to-openapi.test.ts.snap
+++ b/src/openapi/__snapshots__/zod-to-openapi.test.ts.snap
@@ -189,6 +189,10 @@ Object {
         },
       ],
     },
+    "zodDateString": Object {
+      "format": "date-time",
+      "type": "string",
+    },
   },
   "required": Array [
     "stringMinMax",
@@ -205,6 +209,7 @@ Object {
     "record",
     "recordWithKeys",
     "dateString",
+    "zodDateString",
     "password",
     "passwordComplex",
   ],

--- a/src/openapi/zod-to-openapi.test.ts
+++ b/src/openapi/zod-to-openapi.test.ts
@@ -28,6 +28,7 @@ const complexTestSchema = z.object({
   record: z.record(z.number()),
   recordWithKeys: z.record(z.number(), z.string()),
   dateString: z.dateString().cast().describe('My date string'),
+  zodDateString: z.string().datetime(),
   password: z.password(),
   passwordComplex: z
     .password()

--- a/src/openapi/zod-to-openapi.ts
+++ b/src/openapi/zod-to-openapi.ts
@@ -45,6 +45,8 @@ export function zodToOpenAPI(
         object.format = 'cuid'
       } else if (check.kind === 'regex') {
         object.pattern = check.regex.source
+      } else if (check.kind === 'datetime') {
+        object.format = 'date-time'
       }
     }
   }


### PR DESCRIPTION
Currently the native `z.string().datetime()` is not supported. While `ZodDateString` handles this, it means for my project that `nestjs-zod` has to be used in a lower-level package, rather than just in the api/nestjs package where it does the appropriate work on top of the base types.