### PR TITLE
fix: openapi zod enum as keys of record

### DIFF
--- a/src/openapi/zod-to-openapi.ts
+++ b/src/openapi/zod-to-openapi.ts
@@ -218,9 +218,17 @@ export function zodToOpenAPI(
   }
 
   if (is(zodType, z.ZodRecord)) {
-    const { valueType } = zodType._def
+    const { valueType, keyType } = zodType._def
+    const schema = zodToOpenAPI(valueType, visited)
     object.type = 'object'
-    object.additionalProperties = zodToOpenAPI(valueType, visited)
+    if (is(keyType, z.ZodEnum)) {
+      object.properties = {}
+      for (const [, enumKey] of Object.entries(keyType.Values)) {
+        object.properties[enumKey] = schema
+      }
+    } else {
+      object.additionalProperties = schema
+    }
   }
 
   if (is(zodType, z.ZodIntersection)) {


### PR DESCRIPTION
### Issue :
if a zod schema is defined and it has a record which has zod enum as keys something like this 
```typescript
const Subjects = ['USER', 'ROLE'] as const;
const Actions = ['CREATE', 'READ', 'UPDATE', 'DELETE'] as const;

const PermissionsZod = z.record(z.enum(Subjects), z.array(z.enum(Actions)));

const CreateRoleDtoZod = z.object({
  name: z.string(),
  permissions: PermissionsZod,
});

export class CreateRoleDto extends createZodDto(CreateRoleDtoZod) {}
```
In this case genrated schema for openapi is : 
```json
{
  "name": "string",
  "permissions": {
    "additionalProp1": [
      "CREATE"
    ],
    "additionalProp2": [
      "CREATE"
    ],
    "additionalProp3": [
      "CREATE"
    ]
  }
}
```
but it should infer the keys from the provided keys

### Fix :
In this PR have used the provided keys to genrate schema something like this : 
```json
{
  "name": "string",
  "permissions": {
    "USER": [
      "CREATE"
    ],
    "ROLE": [
      "CREATE"
    ]
  }
}
```