### PR TITLE
fix(ISSUE 92): reexport ZodSerializationException

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export type { ZodDto } from './dto'
 export { createZodDto } from './dto'
-export { ZodValidationException } from './exception'
+export { ZodValidationException, ZodSerializationException } from './exception'
 export { createZodGuard, UseZodGuard, ZodGuard } from './guard'
 export { patchNestJsSwagger, zodToOpenAPI } from './openapi'
 export { createZodValidationPipe, ZodValidationPipe } from './pipe'


### PR DESCRIPTION
I created this PR to avoid some tricky situations like this one:
```ts
 if (exception instanceof ZodValidationException) {
      return this.handleZodValidationException(exception);
    }

    // TODO: observe this issue: https://github.com/risen228/nestjs-zod/issues/92 and fix when possible
    // @ts-ignore
    if (exception instanceof InternalServerErrorException && exception.error instanceof ZodError) {
      // @ts-ignore
      return this.handleZodSerializationException(exception);
    }
 ```
 
As you can see, ZodValidationException works fine because it's reexported from index.ts file, but when we need to catch ZodSerializationException, it becomes hard. Please, give me feedback if this PR seems to be okay or not.